### PR TITLE
chores: rename 'Building a Kubernetes Homelab' series to 'K8s Homelab'

### DIFF
--- a/content/posts/homelab-foundation-layer/index.md
+++ b/content/posts/homelab-foundation-layer/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: Deploying the Cluster Infrastructure"
+title: "K8s Homelab: Deploying the Cluster Infrastructure"
 date: 2025-10-28T10:00:00+01:00
 description: "Deploying MetalLB, Traefik Ingress, Longhorn storage, and container registries to create the foundation layer for our Kubernetes cluster"
 tags: ["homelab", "kubernetes", "metallb", "traefik", "longhorn", "storage", "load-balancing", "infrastructure", "ansible", "docker-registry", "container-registry"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the fourth post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-kubernetes-cluster/) to see how we deployed the physical K3s cluster with PXE boot and Butane configurations.*
+*This is the fourth post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-kubernetes-cluster/) to see how we deployed the physical K3s cluster with PXE boot and Butane configurations.*
 
 ## Building the Foundation Layer
 
@@ -590,4 +590,4 @@ The foundation layer is complete and ready to support any workload we deploy to 
 
 ---
 
-*Check out the [previous post](/posts/building-homelab-kubernetes-cluster/) to see how we built the physical cluster, or read the [first post](/posts/building-homelab-introduction/) for the complete journey from the beginning.*
+*Check out the [previous post](/posts/homelab-kubernetes-cluster/) to see how we built the physical cluster, or read the [first post](/posts/homelab-introduction/) for the complete journey from the beginning.*

--- a/content/posts/homelab-gaming-kubevirt/index.md
+++ b/content/posts/homelab-gaming-kubevirt/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: Gaming VMs with KubeVirt and GPU"
+title: "K8s Homelab: Gaming VMs with KubeVirt and GPU"
 date: 2025-11-29T14:00:00+01:00
 description: "Deploying gaming VMs on Kubernetes using KubeVirt with NVIDIA RTX 3080 GPU passthrough, dual-mode operation (live/maintenance), and automated lifecycle management"
 tags: ["homelab", "kubernetes", "kubevirt", "gpu", "passthrough", "virtualization", "gaming", "windows", "linux", "ansible", "cdi", "longhorn"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the sixth post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-lgtm-stack/) to see how we deployed the observability stack with Loki, Grafana, Tempo, and Mimir.*
+*This is the sixth post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-lgtm-stack/) to see how we deployed the observability stack with Loki, Grafana, Tempo, and Mimir.*
 
 ## From Physical Gaming PC to Kubernetes-Native VMs
 
@@ -753,4 +753,4 @@ With this setup, gaming VMs are now Kubernetes-native resources that can be mana
 
 ---
 
-*This is the sixth post in our "Building a Kubernetes Homelab" series. The gaming VMs are now deployed and ready for installation. In future posts, we'll cover VM installation, performance tuning, and backup strategies.*
+*This is the sixth post in our "K8s Homelab" series. The gaming VMs are now deployed and ready for installation. In future posts, we'll cover VM installation, performance tuning, and backup strategies.*

--- a/content/posts/homelab-ha-control-plane/index.md
+++ b/content/posts/homelab-ha-control-plane/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: High Availability for the Control Plane"
+title: "K8s Homelab: High Availability for the Control Plane"
 date: 2025-11-20T15:00:00+01:00
 description: "Implementing HA for the Kubernetes API server using keepalived on host, navigating certificate issues, and building resilient kubeconfig generation with automatic fallback"
 tags: ["homelab", "kubernetes", "high-availability", "keepalived", "k3s", "control-plane", "ansible", "tls", "certificates", "vrrp"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the fifth post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-foundation-layer/) to see how we deployed MetalLB, Traefik, Longhorn, and container registries.*
+*This is the fifth post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-foundation-layer/) to see how we deployed MetalLB, Traefik, Longhorn, and container registries.*
 
 ## The Single Point of Failure Problem
 
@@ -430,4 +430,4 @@ The foundation is now truly resilient, and I can confidently manage the cluster 
 
 ---
 
-*Check out the [previous post](/posts/building-homelab-foundation-layer/) to see how we deployed the cluster infrastructure, or read the [first post](/posts/building-homelab-introduction/) for the complete journey from the beginning.*
+*Check out the [previous post](/posts/homelab-foundation-layer/) to see how we deployed the cluster infrastructure, or read the [first post](/posts/homelab-introduction/) for the complete journey from the beginning.*

--- a/content/posts/homelab-homeassistant/index.md
+++ b/content/posts/homelab-homeassistant/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: HomeAssistant VM with KubeVirt"
+title: "K8s Homelab: HomeAssistant VM with KubeVirt"
 date: 2025-11-29T18:00:00+01:00
 description: "Deploying HomeAssistant OS as a KubeVirt VM on Kubernetes, migrating from Raspberry Pi to a container-native solution with automated lifecycle management"
 tags: ["homelab", "kubernetes", "kubevirt", "homeassistant", "virtualization", "ansible", "cdi", "longhorn", "iot"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the seventh post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-gaming-kubevirt/) to see how we deployed gaming VMs with GPU passthrough.*
+*This is the seventh post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-gaming-kubevirt/) to see how we deployed gaming VMs with GPU passthrough.*
 
 ## From Raspberry Pi to Kubernetes-Native
 

--- a/content/posts/homelab-introduction/index.md
+++ b/content/posts/homelab-introduction/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Building a Kubernetes Homelab: A Long Journey"
+title: "K8s Homelab: A Long Journey"
 date: 2025-09-20T10:00:00+01:00
 description: "Journey from a single gaming PC with VMs to a proper Kubernetes homelab with VLAN-segmented network infrastructure using OpenWRT and managed switches"
 tags: ["homelab", "kubernetes", "networking", "vlan", "openwrt", "ansible", "infrastructure"]
@@ -163,7 +163,7 @@ that comes with network infrastructure projects!
 
 Ready to dive into the technical implementation? Check out the next post in this series:
 
-**[Building a Kubernetes Homelab: From Default ISP Network to VLAN-Segmented](/posts/from-default-isp-to-vlan-segmented/)**
+**[K8s Homelab: From Default ISP Network to VLAN-Segmented](/posts/from-default-isp-to-vlan-segmented/)**
 
 In the next post, we'll cover the detailed implementation of VLAN segmentation, including OpenWRT configuration, managed switch setup, and network security policies.
 

--- a/content/posts/homelab-kubernetes-cluster/index.md
+++ b/content/posts/homelab-kubernetes-cluster/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: From Network Infrastructure to K3s Cluster"
+title: "K8s Homelab: From Network Infrastructure to K3s Cluster"
 date: 2025-10-12T13:00:00+01:00
 description: "Deploying a highly available K3s cluster on Fedora CoreOS with Butane/Ignition, featuring automated provisioning and future PXE-based upgrades"
 tags: ["homelab", "kubernetes", "k3s", "fedora-coreos", "butane", "ignition", "infrastructure", "automation"]
 categories: ["homelab", "kubernetes"]
 ---
 
-This is the third post in my "Building a Kubernetes Homelab" series. If you haven't read the [first post](/posts/building-homelab-introduction/) and [second post](/posts/building-homelab-network/), start there — they set the stage for what comes next.
+This is the third post in my "K8s Homelab" series. If you haven't read the [first post](/posts/homelab-introduction/) and [second post](/posts/homelab-network/), start there — they set the stage for what comes next.
 
 ## The Leap: From Clean VLANs to a Real Cluster
 

--- a/content/posts/homelab-lgtm-stack/index.md
+++ b/content/posts/homelab-lgtm-stack/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: Deploying the LGTM Observability Stack"
+title: "K8s Homelab: Deploying the LGTM Observability Stack"
 date: 2025-01-15T10:00:00+01:00
 description: "Deploying Loki, Grafana, Tempo, and Mimir with Grafana Alloy for comprehensive observability in our Kubernetes homelab"
 tags: ["homelab", "kubernetes", "observability", "lgtm", "loki", "grafana", "tempo", "mimir", "alloy", "monitoring", "ansible"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the fifth post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-foundation-layer/) to see how we deployed MetalLB, Traefik, and Longhorn as the foundation layer.*
+*This is the fifth post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-foundation-layer/) to see how we deployed MetalLB, Traefik, and Longhorn as the foundation layer.*
 
 ## From Infrastructure to Observability
 
@@ -1559,4 +1559,4 @@ In the next post, we'll explore how to expand this observability stack with cust
 
 ---
 
-*Check out the [previous post](/posts/building-homelab-foundation-layer/) to see how we built the foundation infrastructure, or read the [first post](/posts/building-homelab-introduction/) for the complete journey from the beginning.*
+*Check out the [previous post](/posts/homelab-foundation-layer/) to see how we built the foundation infrastructure, or read the [first post](/posts/homelab-introduction/) for the complete journey from the beginning.*

--- a/content/posts/homelab-network/index.md
+++ b/content/posts/homelab-network/index.md
@@ -1,18 +1,18 @@
 ---
-title: "Building a Kubernetes Homelab: the VLAN-Segmented Network"
+title: "K8s Homelab: the VLAN-Segmented Network"
 date: 2025-09-20T11:00:00+01:00
 description: "A personal journey through network automation, hardware failures, and the satisfaction of building a proper homelab infrastructure"
 tags: ["homelab", "networking", "vlan", "openwrt", "security", "infrastructure", "ansible", "story"]
 categories: ["homelab", "networking"]
 ---
 
-*This is the second post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-introduction/) to see how we planned the network architecture.*
+*This is the second post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-introduction/) to see how we planned the network architecture.*
 
 ## The Beginning: A Dream and a Plan
 
 It all started with a simple dream: transform my basic homelab into a properly segmented, Kubernetes-based infrastructure. I had been running everything on a single network for years, and the security implications were starting to keep me up at night. Smart home devices mixed with servers, personal devices sharing the same subnet as my lab equipment – it was a security nightmare waiting to happen.
 
-In the [previous post](/posts/building-homelab-introduction/), I outlined the vision: 5 VLANs (Management, Lab, IoT, Devices, Guests) with proper isolation, automated configuration, and a path to Kubernetes. Now it was time to make it real.
+In the [previous post](/posts/homelab-introduction/), I outlined the vision: 5 VLANs (Management, Lab, IoT, Devices, Guests) with proper isolation, automated configuration, and a path to Kubernetes. Now it was time to make it real.
 
 ## Chapter 1: The First Hardware Choice and Its Betrayal
 
@@ -630,4 +630,4 @@ In the next post, we'll deploy the Kubernetes cluster on the Lab VLAN and begin 
 
 ---
 
-*Check out the [previous post](/posts/building-homelab-introduction/) to see how we planned the network architecture, or read the [first post](/posts/building-homelab-introduction/) for the complete journey from the beginning.*
+*Check out the [previous post](/posts/homelab-introduction/) to see how we planned the network architecture, or read the [first post](/posts/homelab-introduction/) for the complete journey from the beginning.*

--- a/content/posts/homelab-pvc-migration-backup/index.md
+++ b/content/posts/homelab-pvc-migration-backup/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: PVC Migration Strategies"
+title: "K8s Homelab: PVC Migration Strategies"
 date: 2025-11-29T16:00:00+01:00
 description: "Migrating PersistentVolumeClaims between storage classes and implementing backup strategies for VM disk images in a Kubernetes homelab"
 tags: ["homelab", "kubernetes", "storage", "longhorn", "pvc", "backup", "migration", "kubevirt", "data-protection", "ansible"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the seventh post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-gaming-kubevirt/) to see how we deployed gaming VMs with KubeVirt and GPU passthrough.*
+*This is the seventh post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-gaming-kubevirt/) to see how we deployed gaming VMs with KubeVirt and GPU passthrough.*
 
 ## The Storage Optimization Challenge
 
@@ -492,5 +492,5 @@ With proper backup and migration procedures in place, you can confidently optimi
 
 ---
 
-*This is the seventh post in our "Building a Kubernetes Homelab" series. With storage optimized and backup strategies implemented, we're ready to continue building out the homelab infrastructure. In future posts, we'll cover additional storage optimizations, monitoring, and automation strategies.*
+*This is the seventh post in our "K8s Homelab" series. With storage optimized and backup strategies implemented, we're ready to continue building out the homelab infrastructure. In future posts, we'll cover additional storage optimizations, monitoring, and automation strategies.*
 

--- a/content/posts/homelab-registries/index.md
+++ b/content/posts/homelab-registries/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Building a Kubernetes Homelab: Deploying Container Image Registries"
+title: "K8s Homelab: Deploying Container Image Registries"
 date: 2025-11-19T10:00:00+01:00
 description: "Deploying local container registries and mirrors for custom images and upstream caching in our Kubernetes homelab"
 tags: ["homelab", "kubernetes", "container-registry", "docker-registry", "image-mirror", "ansible", "tls"]
 categories: ["homelab", "kubernetes"]
 ---
 
-*This is the sixth post in our "Building a Kubernetes Homelab" series. Check out the [previous post](/posts/building-homelab-lgtm-stack/) to see how we deployed the observability stack.*
+*This is the sixth post in our "K8s Homelab" series. Check out the [previous post](/posts/homelab-lgtm-stack/) to see how we deployed the observability stack.*
 
 ## The Need for Container Registries
 


### PR DESCRIPTION
This PR renames the entire blog series from 'Building a Kubernetes Homelab' to 'K8s Homelab' for brevity and consistency.

## Changes Made

- ✅ Renamed all post folders from `building-homelab-*` to `homelab-*`
- ✅ Updated all post titles from 'Building a Kubernetes Homelab' to 'K8s Homelab'
- ✅ Updated all series references throughout posts
- ✅ Updated all internal links to use new folder names

## Affected Posts

All 10 posts in the series have been updated:
- Introduction
- Network
- Kubernetes Cluster
- Foundation Layer
- HA Control Plane
- LGTM Stack
- Registries
- Gaming KubeVirt
- HomeAssistant
- PVC Migration & Backup